### PR TITLE
chore: use vanilla version of apache LICENCE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,8 +187,8 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 ownCloud GmbH
-   
+   Copyright [yyyy] [name of copyright owner]
+
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at


### PR DESCRIPTION
Replaces the old LICENCE file with the vanilla Apache License 2.0 file from https://www.apache.org/licenses/LICENSE-2.0.txt.

closes https://github.com/opencloud-eu/awesome-apps/issues/4