### PR TITLE
Update documentation link for installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you'd like to contribute to this list, please feel free to make a pull reques
 
 ## OpenCloud Apps and Extensions
 
-Please follow the steps provided in our [developer documentation](https://docs.opencloud.eu/docs/dev/web/extension-system) if you want to install any of the
+Please follow the steps provided in our [documentation](https://docs.opencloud.eu/docs/admin/configuration/web-applications) if you want to install any of the
 following apps and extensions. For some of them there are released artifacts, others still need to be built from source code.
 
 ### Build your own


### PR DESCRIPTION
in 71c35f3ada6a9189739210a40028fbd1ef413aa8 I've fixed the link to the dev-docs (and accidentally committed to main), but I don't think we need the dev-docs here