### PR TITLE
chore: add new web-app-skeleton version

### DIFF
--- a/webApps/apps.json
+++ b/webApps/apps.json
@@ -317,6 +317,11 @@
       "license": "Apache-2.0",
       "versions": [
         {
+          "version": "2.0.0",
+          "minOpenCloud": "6.0.0",
+          "url": "https://github.com/opencloud-eu/web-app-skeleton/archive/refs/heads/main.zip"
+        },
+        {
           "version": "1.0.0",
           "minOpenCloud": "1.0.0",
           "url": "https://github.com/opencloud-eu/web-app-skeleton/releases/download/v1.0.0/skeleton-1.0.0.zip"


### PR DESCRIPTION
Add a new version for web-app-skeleton, linking to the zipped repository on the main branch. Since we don't do (regular) releases for this "app", and the release only contains the source files anyways, I figured we can just do this instead.

closes https://github.com/opencloud-eu/web-app-skeleton/issues/124